### PR TITLE
chore(updatecli) uses the FROM directive

### DIFF
--- a/docker-image/Dockerfile
+++ b/docker-image/Dockerfile
@@ -1,5 +1,4 @@
-ARG JENKINS_VERSION=2.414.1
-FROM jenkins/jenkins:${JENKINS_VERSION}-jdk17
+FROM jenkins/jenkins:2.414.1-jdk17
 
 ## Disable the startup wizard
 RUN echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state

--- a/updatecli/updatecli.d/jenkins-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-lts.yaml
@@ -19,14 +19,14 @@ sources:
     name: Get the latest stable (LTS) Jenkins version
     spec:
       release: stable
+    transformers:
+      - addsuffix: '-jdk17'
 
 conditions:
   testDockerImageExists:
     name: "Does the Docker Image exist on the Docker Hub?"
     kind: dockerimage
     sourceid: latestVersion
-    transformers:
-      - addsuffix: '-jdk17'
     spec:
       image: "jenkins/jenkins"
       architectures:
@@ -40,8 +40,8 @@ targets:
     spec:
       file: docker-image/Dockerfile
       instruction:
-        keyword: "ARG"
-        matcher: "JENKINS_VERSION"
+        keyword: "FROM"
+        matcher: "jenkins/jenkins"
     scmid: default
 
 actions:


### PR DESCRIPTION
This PR only updates the updatecli manifest tracking the LTS version to uses a `FROM` instruction instead of `ARG` and `FROM`.

No changes expected once merged, but the `Dockerfile` will be easier to parse through the plugin update script (to retrieve the Jenkins version).